### PR TITLE
fixed number of land errors

### DIFF
--- a/docs/auxiliary-loops/12-land/deathrite-shaman.md
+++ b/docs/auxiliary-loops/12-land/deathrite-shaman.md
@@ -6,21 +6,21 @@ grand_parent: Auxiliary Loops
 parent: 12-land
 ---
 
-# 12-land Deathrite Shaman Loop
+# 16-land Deathrite Shaman Loop
 
 ## Requirements
 
-* library must be 12 lands and 1 titan
+* library must be 16 lands and 1 titan
 
-To reach this state, discard 11 nonland cards and then discard Kozilek to shuffle all 12 in. Discard 12 lands to draw, then discard Kozilek again to shuffle the lands in and reach the starting state for the loop.
+To reach this state, discard 15 nonland cards and then discard Kozilek to shuffle all 16 in. Discard 16 lands to draw, then discard Kozilek again to shuffle the lands in and reach the starting state for the loop.
 
 ## Procedure
 
 1. Discard Deathrite Shaman
 1. Cast Finale of Devastation for X=10 putting Deathrite Shaman into play from our graveyard
-1. Discard any instant or sorcery notd relevant to our loop
+1. Discard any instant or sorcery not relevant to our loop
 1. Activate Deathite Shaman exiling our instant or sorcery to have each opponets lose 2 life
-1. Sacrifice or Destroy our own Deathrite Shaman
+1. Sacrifice or Destroy our own Deathrite Shaman with Culling the Weak or a removal spell
 1. Discard 2 lands to draw two cards
 1. Discard a land to draw a card. Repeat this by discarding lands drawn this way until our library is empty
 1. Discard our Titan to shuffle itself + Finale + Deathrite + removal spell + 17 lands into our library


### PR DESCRIPTION
First half of loop was using 12 lands, but the remainder clearly was written for 16. So I edited the first half to match. Additionally, fixed 1 typo and added a clarification to step 5